### PR TITLE
Rails cors matches localhost regex

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,8 @@ module LemonadeApi
     config.api_only = true
     config.middleware.insert_before 0, Rack::Cors do
       allow do
-        origins ENV['RAILS_CORS_ORIGINS'] || 'localhost:4200'
+        origins ENV['RAILS_CORS_ORIGINS'] || /https?:\/\/localhost:(\d*)/
+
         resource '*',
           headers: :any,
           methods: [:get, :post, :options, :delete, :put],


### PR DESCRIPTION
When environment RAILS_CORS_ORIGINS is not defined it will allow all
localhost connections, not only on port 4200