### PR TITLE
Run container using ruby as base image and fix rails envs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,6 @@
-FROM rails:onbuild
+FROM ruby:onbuild
 MAINTAINER Guilherme Maluf <guimalufb@gmail.com>
+
+ENV RAILS_ENV docker
+EXPOSE 3000
+CMD ["/bin/bash", "/usr/src/app/run"]

--- a/README.md
+++ b/README.md
@@ -35,18 +35,12 @@ Run thorn with docker
 docker run --rm \
   -e MYSQL_ROOT_PASSWORD="" \
   -e MYSQL_ALLOW_EMPTY_PASSWORD=yes \
-  -v /var/run/mysqld/ \
   --name thorn_mysql mariadb
-
-# Setup database
-docker run --rm \
-  --volumes-from thorn_mysql \
-  bigsea/thorn rake db:setup
 
 # Run rails
 docker run --rm \
   -e RAILS_CORS_ORIGINS=localhost:8080 \
   -p 3000:3000 \
-  --volumes-from thorn_mysql \
+  --link thorn_mysql:mysql \
   bigsea/thorn
 ```

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,3 +20,8 @@ production:
   username: thorn
   password: thornsecret
   host: citron.ctweb.inweb.org.br
+
+docker:
+  <<: *default
+  database: thorn
+  host: mysql

--- a/config/environments/docker.rb
+++ b/config/environments/docker.rb
@@ -1,0 +1,74 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "lemonade_api_#{Rails.env}"
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -22,3 +22,6 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: f598f0eba4a9a2c16c4af8b92c1f04d7270213e060b6c6ecb73a7b8e612ab255a51d4b945375c26d0c7e4698d76458e2b02aa72ed4cbb58d8c32fef0dd352771
+
+docker:
+  secret_key_base: f598f0eba4a9a2c16c4af8b92c1f04d7270213e060b6c6ecb73a7b8e612ab255a51d4b945375c26d0c7e4698d76458e2b02aa72ed4cbb58d8c32fef0dd352771

--- a/config/unicorn/docker.rb
+++ b/config/unicorn/docker.rb
@@ -1,0 +1,16 @@
+app_path = "/usr/src/app"
+working_directory "#{app_path}"
+worker_processes 4
+listen "/tmp/thorn.sock", backlog: 64
+listen 3000
+pid "#{app_path}/tmp/unicorn.pid"
+timeout 60
+stderr_path "/dev/stdout"
+
+before_fork do |server, worker|
+  defined?(ActiveRecord::Base) and ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+  defined?(ActiveRecord::Base) and ActiveRecord::Base.establish_connection
+end

--- a/run
+++ b/run
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle exec rake db:setup || bundle exec rake db:migrate
+bundle exec unicorn -c config/unicorn/docker.rb -E docker


### PR DESCRIPTION
Thorn container uses deprecated rails container as base and access mysql
database using a socket

This commit uses ruby:onbuild as base container and uses link to access
mysql database. It also configure an rails environment for docker which
is a copy os production.