### PR TITLE
Change docker CMD script

### DIFF
--- a/run
+++ b/run
@@ -2,5 +2,5 @@
 PID_FILE=/usr/src/app/tmp/unicorn.pid
 [ -f "$PID_FILE" ] && rm "$PID_FILE"
 
-bundle exec rake db:create rake db:migrate
+bundle exec rake db:create db:migrate
 bundle exec unicorn -c config/unicorn/docker.rb -E docker


### PR DESCRIPTION
Docker run script was calling `rake db:schema:load` which overrides
database configuration

This commits fix this