### PR TITLE
Change container bundle to not use dev/test environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
-FROM ruby:onbuild
+FROM ruby:2.4
 MAINTAINER Guilherme Maluf <guimalufb@gmail.com>
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+RUN bundle install --without development:test
+
+COPY . /usr/src/app
 
 ENV RAILS_ENV docker
 EXPOSE 3000


### PR DESCRIPTION
ruby:onbuild is used to build thorn but it lacks means to run bundle
without development and test environments

This commit copies the content of ruby/2.4-onbuild/Dockerfile and
includes options to run bundle without dev/test environment